### PR TITLE
Feature/invalidate zero page size argument

### DIFF
--- a/CorePagination/Extensions/PaginatorExtensions.cs
+++ b/CorePagination/Extensions/PaginatorExtensions.cs
@@ -30,7 +30,7 @@ namespace CorePagination.Extensions
         {
             Guard.NotNull(query, nameof(query));
             Guard.GreaterThanZero(pageNumber, nameof(pageNumber));
-
+            Guard.GreaterThanZero(pageSize, nameof(pageSize));
 
             var items = query.Skip((pageNumber - 1) * pageSize).Take(pageSize).ToList();
             return new PaginationResult<T>
@@ -56,7 +56,7 @@ namespace CorePagination.Extensions
         {
             Guard.NotNull(query, nameof(query));
             Guard.GreaterThanZero(pageNumber, nameof(pageNumber));
-
+            Guard.GreaterThanZero(pageSize, nameof(pageSize));
 
             var totalItems = query.Count();
             var totalPages = (int)Math.Ceiling(totalItems / (double)pageSize);
@@ -91,6 +91,7 @@ namespace CorePagination.Extensions
         {
             Guard.NotNull(query, nameof(query));
             Guard.NotNull(keySelector, nameof(keySelector));
+            Guard.GreaterThanZero(pageSize, nameof(pageSize));
 
             var paginator = new CursorPaginator<T, TKey>(keySelector);
             var parameters = new CursorPaginationParameters<TKey> { PageSize = pageSize, CurrentCursor = currentCursor, Order = order };
@@ -112,7 +113,7 @@ namespace CorePagination.Extensions
         {
             Guard.NotNull(query, nameof(query));
             Guard.GreaterThanZero(pageNumber, nameof(pageNumber));
-
+            Guard.GreaterThanZero(pageSize, nameof(pageSize));
 
             var items = await query.Skip((pageNumber - 1) * pageSize).Take(pageSize).ToListAsync();
             return new PaginationResult<T>
@@ -139,6 +140,7 @@ namespace CorePagination.Extensions
         {
             Guard.NotNull(query, nameof(query));
             Guard.GreaterThanZero(pageNumber, nameof(pageNumber));
+            Guard.GreaterThanZero(pageSize, nameof(pageSize));
 
 
             var items = await query.Skip((pageNumber - 1) * pageSize).Take(pageSize).ToListAsync();
@@ -172,6 +174,7 @@ namespace CorePagination.Extensions
         {
             Guard.NotNull(query, nameof(query));
             Guard.NotNull(keySelector, nameof(keySelector));
+            Guard.GreaterThanZero(pageSize, nameof(pageSize));
 
             var paginator = new CursorPaginator<T, TKey>(keySelector);
             var parameters = new CursorPaginationParameters<TKey> { PageSize = pageSize, CurrentCursor = currentCursor, Order = order };

--- a/CorePagination/Paginators/CursorPaginator/CursorPaginator.cs
+++ b/CorePagination/Paginators/CursorPaginator/CursorPaginator.cs
@@ -39,6 +39,7 @@ namespace CorePagination.Paginators.CursorPaginator {
         {
             Guard.NotNull(query, nameof(query));
             Guard.NotNull(parameters, nameof(parameters));
+            Guard.GreaterThanZero(parameters.PageSize, nameof(parameters.PageSize));
 
             IQueryable<T> orderedQuery = parameters.Order == PaginationOrder.Ascending
                 ? query.OrderBy(_keySelector)
@@ -92,6 +93,7 @@ namespace CorePagination.Paginators.CursorPaginator {
         {
             Guard.NotNull(query, nameof(query));
             Guard.NotNull(parameters, nameof(parameters));
+            Guard.GreaterThanZero(parameters.PageSize, nameof(parameters.PageSize));
 
             IQueryable<T> orderedQuery = parameters.Order == PaginationOrder.Ascending
                 ? query.OrderBy(_keySelector)

--- a/CorePagination/Paginators/SimplePaginator/SimplePaginator.cs
+++ b/CorePagination/Paginators/SimplePaginator/SimplePaginator.cs
@@ -27,6 +27,7 @@ namespace CorePagination.Paginators.SimplePaginator
             Guard.NotNull(query, nameof(query));
             Guard.NotNull(parameters, nameof(parameters));
             Guard.GreaterThanZero(parameters.Page, nameof(parameters.Page));
+            Guard.GreaterThanZero(parameters.PageSize, nameof(parameters.PageSize));
 
             var items = query.Skip((parameters.Page - 1) * parameters.PageSize).Take(parameters.PageSize).ToList();
             return new PaginationResult<T>
@@ -49,6 +50,7 @@ namespace CorePagination.Paginators.SimplePaginator
             Guard.NotNull(query, nameof(query));
             Guard.NotNull(parameters, nameof(parameters));
             Guard.GreaterThanZero(parameters.Page, nameof(parameters.Page));
+            Guard.GreaterThanZero(parameters.PageSize, nameof(parameters.PageSize));
 
             var items = await query.Skip((parameters.Page - 1) * parameters.PageSize).Take(parameters.PageSize).ToListAsync();
             return new PaginationResult<T>

--- a/CorePagination/Paginators/SizeAwarePaginator/SizeAwarePaginator.cs
+++ b/CorePagination/Paginators/SizeAwarePaginator/SizeAwarePaginator.cs
@@ -23,6 +23,7 @@ namespace CorePagination.Paginators.SizeAwarePaginator
             Guard.NotNull(query, nameof(query));
             Guard.NotNull(parameters, nameof(parameters));
             Guard.GreaterThanZero(parameters.Page, nameof(parameters.Page));
+            Guard.GreaterThanZero(parameters.PageSize, nameof(parameters.PageSize));
 
             var totalItems = query.Count();
             var totalPages = (int)Math.Ceiling(totalItems / (double)parameters.PageSize);
@@ -49,7 +50,7 @@ namespace CorePagination.Paginators.SizeAwarePaginator
             Guard.NotNull(query, nameof(query));
             Guard.NotNull(parameters, nameof(parameters));
             Guard.GreaterThanZero(parameters.Page, nameof(parameters.Page));
-
+            Guard.GreaterThanZero(parameters.PageSize, nameof(parameters.PageSize));
 
             var items = await query.Skip((parameters.Page - 1) * parameters.PageSize).Take(parameters.PageSize).ToListAsync();
             var totalItems = await query.CountAsync();


### PR DESCRIPTION
# Implement PageSize Validation in Pagination Methods

This pull request introduces additional validation to ensure that the `pageSize` provided to pagination methods is greater than zero. This update affects both `SimplePaginator` and `SizeAwarePaginator` classes, as well as the corresponding extensions in `PaginatorExtensions`.

## Key Changes:

- **`GreaterThanZero` Guard Enhancement:** The existing `GreaterThanZero` method in the `Guard` class is now utilized to validate the `pageSize` in addition to the `pageNumber`. This ensures that neither `pageNumber` nor `pageSize` can be zero or negative, aligning with logical pagination requirements.

- **Validation in Pagination Methods:** The `GreaterThanZero` validation for `pageSize` has been integrated into the `Paginate` and `PaginateAsync` methods of `SimplePaginator` and `SizeAwarePaginator`, along with their respective extension methods. This addition guarantees that an exception is thrown if a `pageSize` of zero or less is provided, thereby maintaining the robustness of the pagination logic. Also this apply to `CursorPaginator`

## Checklist:

- [x] Code compiles without errors.
- [ ] All existing unit tests pass with the new changes.


